### PR TITLE
Release/0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
 ## unreleased
+## v0.2.0
 
 - Support Kotlin types coming from compiled dependencies (KSP `Origin.KOTLIN_LIB`), so models from a depended-on SDK module (via `api`/`implementation`) work across the interop boundary:
-  - `requiresSerialization()` now serializes `KOTLIN_LIB` classes in addition to `KOTLIN` ones
-  - `filterTypesForGeneration()` now generates Dart models for `KOTLIN_LIB` types, restricted to the class kinds `toDartType()` can handle (data class, sealed class, enum, object) so stdlib base classes (e.g. `kotlin.Enum`) reached via super-type traversal and unresolved error types do not leak into code generation
+  - `requiresSerialization()` and `filterTypesForGeneration()` now handle `KOTLIN_LIB` types, restricted to the class kinds that are serializable models (data class, sealed class, enum, object). Plain stdlib classes like `kotlin.String`/`kotlin.Int` (also `KOTLIN_LIB`) are intentionally excluded, so the native side does not try to JSON-decode raw primitive values
+  - stdlib base classes (e.g. `kotlin.Enum`) reached via super-type traversal and unresolved error types no longer leak into code generation
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 ## unreleased
+
+- Support Kotlin types coming from compiled dependencies (KSP `Origin.KOTLIN_LIB`), so models from a depended-on SDK module (via `api`/`implementation`) work across the interop boundary:
+  - `requiresSerialization()` now serializes `KOTLIN_LIB` classes in addition to `KOTLIN` ones
+  - `filterTypesForGeneration()` now generates Dart models for `KOTLIN_LIB` types, restricted to the class kinds `toDartType()` can handle (data class, sealed class, enum, object) so stdlib base classes (e.g. `kotlin.Enum`) reached via super-type traversal and unresolved error types do not leak into code generation
+
 ## v0.1.0
 
 - Update Nexus repository URLs for publishing

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
-val flutterKmpVersion = "0.1.0"
+val flutterKmpVersion = "0.2.0"
 
 kotlin {
     jvm()

--- a/example/flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat May 25 02:36:17 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/flutter-kmp-ksp/src/main/kotlin/de/voize/flutterkmp/ksp/processor/utils.kt
+++ b/flutter-kmp-ksp/src/main/kotlin/de/voize/flutterkmp/ksp/processor/utils.kt
@@ -184,10 +184,16 @@ fun KSDeclaration.requiresSerialization(): Boolean {
 
     return qualifiedName?.asString() in types
            || (this is KSClassDeclaration && when (this.classKind) {
-        // KOTLIN_LIB covers Kotlin classes that come from a compiled dependency
-        // (e.g. when the binding module depends on the SDK module via api/implementation).
-        // Both origins represent Kotlin data classes that need JSON serialization.
-        ClassKind.CLASS -> this.origin == Origin.KOTLIN || this.origin == Origin.KOTLIN_LIB
+        // For compiled dependencies (Origin.KOTLIN_LIB) ONLY data/sealed classes are
+        // serializable models. Plain stdlib classes like kotlin.String / kotlin.Int are also
+        // KOTLIN_LIB, so we must NOT mark them as requiring serialization — otherwise the
+        // native side tries to JSON-decode a raw (unquoted) value (e.g. `test`) and aborts
+        // at runtime. This mirrors the KOTLIN_LIB handling in filterTypesForGeneration().
+        ClassKind.CLASS -> when (this.origin) {
+            Origin.KOTLIN -> true
+            Origin.KOTLIN_LIB -> Modifier.DATA in this.modifiers || Modifier.SEALED in this.modifiers
+            else -> false
+        }
                ClassKind.OBJECT -> true
                ClassKind.ENUM_CLASS -> true
                else -> false

--- a/flutter-kmp-ksp/src/main/kotlin/de/voize/flutterkmp/ksp/processor/utils.kt
+++ b/flutter-kmp-ksp/src/main/kotlin/de/voize/flutterkmp/ksp/processor/utils.kt
@@ -2,7 +2,17 @@ package de.voize.flutterkmp.ksp.processor
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -174,7 +184,10 @@ fun KSDeclaration.requiresSerialization(): Boolean {
 
     return qualifiedName?.asString() in types
            || (this is KSClassDeclaration && when (this.classKind) {
-               ClassKind.CLASS -> this.origin == Origin.KOTLIN
+        // KOTLIN_LIB covers Kotlin classes that come from a compiled dependency
+        // (e.g. when the binding module depends on the SDK module via api/implementation).
+        // Both origins represent Kotlin data classes that need JSON serialization.
+        ClassKind.CLASS -> this.origin == Origin.KOTLIN || this.origin == Origin.KOTLIN_LIB
                ClassKind.OBJECT -> true
                ClassKind.ENUM_CLASS -> true
                else -> false
@@ -205,12 +218,29 @@ fun filterTypesForGeneration(types: Set<KSDeclaration>): Collection<KSDeclaratio
             "kotlinx.datetime.LocalDateTime",
             "kotlinx.datetime.LocalTime",
         )
-        it.qualifiedName?.asString() !in defaultTypes
+        it.qualifiedName != null && it.qualifiedName?.asString() !in defaultTypes
     }
 
     return customTypes.filter {
         when (it) {
-            is KSClassDeclaration -> it.classKind != ClassKind.INTERFACE && it.origin == Origin.KOTLIN
+            is KSClassDeclaration ->
+                when (it.origin) {
+                    // KOTLIN (same-module sources): accept anything that is not an interface —
+                    // same behaviour as before the KOTLIN_LIB extension.
+                    Origin.KOTLIN -> it.classKind != ClassKind.INTERFACE
+                    // KOTLIN_LIB (compiled dependency): only accept the exact class kinds that
+                    // toDartType() can handle. This prevents stdlib base classes like kotlin.Enum,
+                    // kotlin.Comparable, etc. — which appear via superType traversal in
+                    // findAllUsedTypes — from leaking through and crashing code generation.
+                    Origin.KOTLIN_LIB -> when (it.classKind) {
+                        ClassKind.CLASS -> Modifier.DATA in it.modifiers || Modifier.SEALED in it.modifiers
+                        ClassKind.ENUM_CLASS -> true
+                        ClassKind.OBJECT -> true
+                        else -> false
+                    }
+
+                    else -> false
+                }
             is KSTypeParameter -> false
             else -> true
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.0
+version=0.2.0
 group=de.voize
 
 org.gradle.jvmargs=-Xmx2048m

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+set -euo pipefail
 
 VERSION=${1}
 GIT_TAG=v${VERSION}
-BASEDIR=$(dirname $(readlink -f "$0"))
+# Portable BASEDIR resolution (BSD readlink has no -f).
+BASEDIR="$(cd "$(dirname "$0")/.." && pwd)"
 (
-    cd "$BASEDIR/.."
-    sed -i "s/version=.*/version=${VERSION}/g" gradle.properties
-    sed -i "/\#\# unreleased/a \#\# ${GIT_TAG}" CHANGELOG.md
-    sed -i "s/val flutterKmpVersion = .*/val flutterKmpVersion = \"${VERSION}\"/g" example/build.gradle.kts
+    cd "$BASEDIR"
+    # Use perl for in-place edits: identical behaviour on BSD (macOS) and GNU (Linux/CI),
+    # unlike `sed -i` whose syntax differs between the two.
+    perl -i -pe "s/^version=.*/version=${VERSION}/" gradle.properties
+    perl -i -pe "s/^## unreleased\$/## unreleased\n## ${GIT_TAG}/" CHANGELOG.md
+    perl -i -pe "s/val flutterKmpVersion = .*/val flutterKmpVersion = \"${VERSION}\"/" example/build.gradle.kts
     git commit -m "version ${VERSION}" gradle.properties CHANGELOG.md example/build.gradle.kts
-    git tag -a $GIT_TAG -m "version ${VERSION}"
+    git tag -a "$GIT_TAG" -m "version ${VERSION}"
 )


### PR DESCRIPTION
- Support Kotlin types coming from compiled dependencies (KSP `Origin.KOTLIN_LIB`), so models from a depended-on SDK module (via `api`/`implementation`) work across the interop boundary:
  - `requiresSerialization()` now serializes `KOTLIN_LIB` classes in addition to `KOTLIN` ones
  - `filterTypesForGeneration()` now generates Dart models for `KOTLIN_LIB` types, restricted to the class kinds `toDartType()` can handle (data class, sealed class, enum, object) so stdlib base classes (e.g. `kotlin.Enum`) reached via super-type traversal and unresolved error types do not leak into code generation